### PR TITLE
WIP: Distinguish between gateway an peer trafic.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,9 +300,9 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "celes"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30b649e0a7a41e2ea1714e65e5bc5c857ddca7569752fa540ab7c582344c178"
+checksum = "39b9a21273925d7cc9e8a9a5f068122341336813c607014f5ef64f82b6acba58"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,6 +2102,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",

--- a/bitswap-monitoring-client/Cargo.toml
+++ b/bitswap-monitoring-client/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 ipfs-resolver-common = { path = "../common" }
 ipfs_monitoring_plugin_client = { path = "../ipfs-monitoring-plugin-client" }
-tokio = { version = "1", features = ["rt", "net", "sync", "rt-multi-thread","time", "macros"] }
+tokio = { version = "1", features = ["rt", "net", "sync", "rt-multi-thread","time", "macros", "signal"] }
 log = "0.4.14"
 flexi_logger = "0.22.5"
 failure = "0.1.8"

--- a/bitswap-monitoring-client/Cargo.toml
+++ b/bitswap-monitoring-client/Cargo.toml
@@ -28,4 +28,4 @@ maxminddb = "0.23.0"
 multiaddr = "0.14"
 
 # ISO 3166-1 countries.
-celes = "2.2.0"
+celes = "2.4.0"

--- a/bitswap-monitoring-client/config.yaml
+++ b/bitswap-monitoring-client/config.yaml
@@ -7,6 +7,11 @@ prometheus_address: "0.0.0.0:8088"
 # Defaults to /usr/local/share/GeoIP if unspecified.
 #geoip_database_path: "/usr/local/share/GeoIP"
 
+# Specifies where the gateway file is located.
+# In the gateway file every line should be the id of an ipfs-gateway.
+# If not provided all traffic will be logged as non-gateway-traffic.
+gateway_file_path: "/usr/local/share/gateways.txt"
+
 # List of monitors to connect to.
 monitors:
   - name: "local"

--- a/bitswap-monitoring-client/src/config.rs
+++ b/bitswap-monitoring-client/src/config.rs
@@ -18,10 +18,20 @@ pub(crate) struct Config {
     /// Defaults to /usr/local/share/GeoIP if unspecified.
     #[serde(default = "default_geoip_database_path")]
     pub(crate) geoip_database_path: String,
+
+    /// Specifies where the gateway file is located.
+    /// In the gateway file every line should be the id of an ipfs-gateway.
+    /// If not provided all traffic will be logged as non-gateway-traffic.
+    #[serde(default = "default_gateway_file_path")]
+    pub(crate) gateway_file_path: Option<String>,
 }
 
 fn default_geoip_database_path() -> String {
     "/usr/local/share/GeoIP".to_string()
+}
+
+fn default_gateway_file_path() -> Option<String> {
+    None
 }
 
 /// Configuration for a single monitor to connect to.

--- a/bitswap-monitoring-client/src/prom.rs
+++ b/bitswap-monitoring-client/src/prom.rs
@@ -1,4 +1,5 @@
-use failure::{err_msg, ResultExt};
+use celes::EmptyLookupTable;
+use failure::ResultExt;
 use ipfs_resolver_common::Result;
 use prometheus::core::{AtomicU64, GenericCounter};
 use prometheus::IntCounterVec;
@@ -9,60 +10,73 @@ lazy_static! {
         pub static ref BITSWAP_MESSAGES_RECEIVED: IntCounterVec = register_int_counter_vec!(
         "bitswap_messages_received",
         "number of bitswap messages (both requests and responses) received by monitor and origin country",
-        &["monitor","origin_country"]
+        &["monitor","origin_country","origin_is_gateway"]
     )
     .unwrap();
 
     pub static ref BITSWAP_BLOCKS_RECEIVED: IntCounterVec = register_int_counter_vec!(
         "bitswap_blocks_received",
         "number of blocks received via bitswap, by monitor and origin country",
-        &["monitor","origin_country"]
+        &["monitor","origin_country","origin_is_gateway"]
     )
     .unwrap();
 
     pub static ref BITSWAP_BLOCK_PRESENCES_RECEIVED: IntCounterVec = register_int_counter_vec!(
         "bitswap_block_presences_received",
         "number of block presences received via bitswap, by monitor, presence type, and origin country",
-        &["monitor","presence_type","origin_country"]
+        &["monitor","presence_type","origin_is_gateway","origin_country"]
     )
     .unwrap();
 
     pub static ref WANTLIST_ENTRIES_RECEIVED: IntCounterVec = register_int_counter_vec!(
         "wantlist_entries_received",
         "number of wantlist entries received by monitor, entry type, send_dont_have, and origin country",
-        &["monitor", "entry_type", "send_dont_have","origin_country"]
+        &["monitor","entry_type","origin_is_gateway","send_dont_have","origin_country"]
     )
     .unwrap();
 
     pub static ref WANTLISTS_RECEIVED: IntCounterVec = register_int_counter_vec!(
         "wantlists_received",
         "number of bitswap messages received for which the wantlist was not empty, by monitor, whether the wantlist was a full wantlist, and origin country",
-        &["monitor","full","origin_country"]
+        &["monitor","full","origin_is_gateway","origin_country"]
     )
     .unwrap();
 
     pub static ref CONNECTION_EVENTS_CONNECTED: IntCounterVec = register_int_counter_vec!(
         "connection_events_connected",
         "number of connect events by monitor and origin country",
-        &["monitor","origin_country"]
+        &["monitor","origin_country","origin_is_gateway"]
     )
     .unwrap();
 
     pub static ref CONNECTION_EVENTS_DISCONNECTED: IntCounterVec = register_int_counter_vec!(
         "connection_events_disconnected",
         "number of disconnect events by monitor and origin country",
-        &["monitor","origin_country"]
+        &["monitor","origin_country","origin_is_gateway"]
     )
     .unwrap();
 }
 
-/// Country name and code constants for various error conditions.
-/// These are used as both the two-letter country code and the full country name.
-pub(crate) static COUNTRY_NAME_UNKNOWN: &'static str = "Unknown";
-pub(crate) static COUNTRY_NAME_ERROR: &'static str = "Error";
+/// Country constants for various error conditions.
+pub(crate) static COUNTRY_NAME_UNKNOWN: celes::Country = celes::Country {
+    code: "Unkown",
+    value: 0,
+    alpha2: "Unkown",
+    alpha3: "Unkown",
+    long_name: "Unkown",
+    aliases: celes::CountryTable::Empty(EmptyLookupTable([])),
+};
+pub(crate) static COUNTRY_NAME_ERROR: celes::Country = celes::Country {
+    code: "Error",
+    value: 0,
+    alpha2: "Error",
+    alpha3: "Error",
+    long_name: "Error",
+    aliases: celes::CountryTable::Empty(EmptyLookupTable([])),
+};
 
 /// A set of metrics instantiated by monitor name and country.
-pub(crate) struct MetricsByMonitorAndCountry {
+pub(crate) struct Metrics {
     /// Counter for Bitswap messages.
     pub(crate) num_messages: GenericCounter<AtomicU64>,
 
@@ -89,32 +103,53 @@ pub(crate) struct MetricsByMonitorAndCountry {
     pub(crate) num_disconnected: GenericCounter<AtomicU64>,
 }
 
-impl MetricsByMonitorAndCountry {
+/// Distinguish traffic by the type of the origin
+/// If the origin is a real IPFS-note the type should be Peer
+/// If the origin is a HTTP to IPFS proxy the type should be Gateway
+#[derive(Debug, Hash, Eq, PartialEq, Clone, Copy)]
+pub enum OriginType {
+    Peer,
+    Gateway,
+}
+
+impl Metrics {
     /// Creates a set of metrics consisting of a few popular countries and the special
     /// error-condition countries, for the given monitor.
     pub(crate) fn create_basic_set(
         monitor_name: &str,
-    ) -> HashMap<String, MetricsByMonitorAndCountry> {
+    ) -> HashMap<(celes::Country, OriginType), Metrics> {
         let mut metrics_by_country = IntoIterator::into_iter([
-            celes::Country::germany(),
-            celes::Country::the_united_states_of_america(),
-            celes::Country::the_netherlands(),
-        ])
-        .map(|c| {
+            (celes::Country::germany(), OriginType::Peer),
             (
-                c.alpha2.to_string(),
-                Self::new_from_iso3166_alpha2(monitor_name, c.alpha2).unwrap(),
-            )
-        })
+                celes::Country::the_united_states_of_america(),
+                OriginType::Peer,
+            ),
+            (celes::Country::the_netherlands(), OriginType::Peer),
+            (celes::Country::germany(), OriginType::Gateway),
+            (
+                celes::Country::the_united_states_of_america(),
+                OriginType::Gateway,
+            ),
+            (celes::Country::the_netherlands(), OriginType::Gateway),
+        ])
+        .map(|c| (c, Self::new_for_country(monitor_name, c.0)))
         .collect::<HashMap<_, _>>();
 
         // Add special error-countries.
         metrics_by_country.insert(
-            COUNTRY_NAME_UNKNOWN.to_string(),
+            (COUNTRY_NAME_UNKNOWN, OriginType::Peer),
             Self::new_unknown(monitor_name),
         );
         metrics_by_country.insert(
-            COUNTRY_NAME_ERROR.to_string(),
+            (COUNTRY_NAME_ERROR, OriginType::Peer),
+            Self::new_error(monitor_name),
+        );
+        metrics_by_country.insert(
+            (COUNTRY_NAME_UNKNOWN, OriginType::Gateway),
+            Self::new_unknown(monitor_name),
+        );
+        metrics_by_country.insert(
+            (COUNTRY_NAME_ERROR, OriginType::Gateway),
             Self::new_error(monitor_name),
         );
 
@@ -123,18 +158,20 @@ impl MetricsByMonitorAndCountry {
 
     /// Creates a set of metrics with their `origin_country` set to "Unknown".
     /// This is used for events for which no origin can be determined.
-    fn new_unknown(monitor_name: &str) -> MetricsByMonitorAndCountry {
-        Self::new_from_country_name(monitor_name, COUNTRY_NAME_UNKNOWN)
+    fn new_unknown(monitor_name: &str) -> Metrics {
+        Self::new_for_country(monitor_name, COUNTRY_NAME_UNKNOWN)
     }
 
     /// Creates a set of metrics with their `origin_country` set to "Error".
     /// This is used for events for which determining the origin country failed.
-    fn new_error(monitor_name: &str) -> MetricsByMonitorAndCountry {
-        Self::new_from_country_name(monitor_name, COUNTRY_NAME_ERROR)
+    fn new_error(monitor_name: &str) -> Metrics {
+        Self::new_for_country(monitor_name, COUNTRY_NAME_ERROR)
     }
 
-    fn new_from_country_name(monitor_name: &str, country_name: &str) -> MetricsByMonitorAndCountry {
-        MetricsByMonitorAndCountry {
+    /// Creates a new set of metrics for the country
+    pub(crate) fn new_for_country(monitor_name: &str, country: celes::Country) -> Metrics {
+        let country_name = country.long_name;
+        Metrics {
             num_messages: BITSWAP_MESSAGES_RECEIVED
                 .get_metric_with_label_values(&[monitor_name, country_name])
                 .unwrap(),
@@ -177,19 +214,6 @@ impl MetricsByMonitorAndCountry {
                 .get_metric_with_label_values(&[monitor_name, "DONT_HAVE", country_name])
                 .unwrap(),
         }
-    }
-
-    /// Creates a new set of metrics for the country identified by `country_code`.
-    /// If `country_code` is not a valid 2-letter ISO3166-1 code, an error is returned.
-    pub(crate) fn new_from_iso3166_alpha2(
-        monitor_name: &str,
-        country_code: &str,
-    ) -> Result<MetricsByMonitorAndCountry> {
-        let country = celes::Country::from_alpha2(country_code)
-            .map_err(|e| err_msg(format!("{}", e)))
-            .context("invalid country code")?;
-
-        Ok(Self::new_from_country_name(monitor_name, country.long_name))
     }
 }
 


### PR DESCRIPTION
The monitor-client should now be able to read gateway-ids from a file
(Filepath is given in cfg, every line should be on gateway-id, uniqueness not necessary). 

If the process receives an SIGUSR1-Signal it tries to update its gateway-data from the same file as above.

TODO:
- Handle origin_is_gateway datafield correctly. Glue together with prometheus.
- Testing
 